### PR TITLE
update the database even when there is nothing for a given channel

### DIFF
--- a/helga_yelling.py
+++ b/helga_yelling.py
@@ -44,10 +44,10 @@ def yelling(client, channel, nick, message, *args):
 
                 client.msg(channel, random_resp['msg'])
 
-                db.yelling.update_one({
-                    'msg': message,
-                    'channel': channel,
-                }, { '$set': { 'msg': message } }, upsert=True)
+            db.yelling.update_one({
+                'msg': message,
+                'channel': channel,
+            }, { '$set': { 'msg': message } }, upsert=True)
 
         return (channel, nick, message)
 


### PR DESCRIPTION
This correctly existed as https://github.com/bigjust/helga-yelling/commit/14202005ac7c950dee96c0b1f5508b65c2d8faa1

But later got changed only to work if `count()` was non-zero (previous activity was recorded for a channel) https://github.com/bigjust/helga-yelling/commit/18b07ab8f73e9a78fddfba909773b7ded0c6d4bd 

This fixes the problem of not getting anything stored in a channel that never had any activity before.

There were no tests that talk to mongo, unsure if using pytest-style tests would be OK since existing tests are using `unittest.TestCase`